### PR TITLE
Make OIDC config more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,17 @@
 # Change Log
 
-## [0.1.1] - 2021-04-11
+## [1.0.0] - 2021-04-22
 
-### Added
+- Allow non-keycloak well_known endpoints and usage without a well_known
+  endpoint. This changes the interface of the OIDC config object.
+
+## [0.1.1] - 2021-04-11
 
 - Testing of OPA middleware and OIDC authentication as well as the
   pipeline setup for executing tests, style checks and dependency audit.
   ([#4](https://github.com/busykoala/fastapi-opa/pull/4))
   
 ## [0.1.0] - 2021-04-03
-
-### Added
 
 - Initial implementation of OPA middleware and OIDC authentication.
 - Package documentation and usage instructions.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ from fastapi_opa.auth import OIDCConfig
 opa_host = "http://localhost:8181"
 # In this example we use OIDC authentication flow (using Keycloak)
 oidc_config = OIDCConfig(
-    host="http://localhost:8080",  # host of your identity provider
-    realm="example-realm",  # realm id of your identity provider
+    well_known_endpoint="http://localhost:8000/auth/realms/example-realm/.well-known/openid-configuration",  # well known endpoint
     app_uri="http://localhost:4000",  # host where this app is running
     client_id="example-client",  # client id of your app configured in the identity provider
     client_secret="bbb4857c-21ba-44a3-8843-1364984a36906",  # the client secret retrieved from your identity provider

--- a/fastapi_opa/auth/auth_oidc.py
+++ b/fastapi_opa/auth/auth_oidc.py
@@ -46,7 +46,12 @@ class OIDCAuthentication(OIDCAuthenticationInterface):
         self.config = config
         if self.config.well_known_endpoint:
             self.set_from_well_known()
-        elif self.config.issuer and self.config.authorization_endpoint and self.config.token_endpoint and self.config.jwks_uri:
+        elif (
+            self.config.issuer
+            and self.config.authorization_endpoint
+            and self.config.token_endpoint
+            and self.config.jwks_uri
+        ):
             self.issuer = self.config.issuer
             self.authorization_endpoint = self.config.authorization_endpoint
             self.token_endpoint = self.config.token_endpoint
@@ -58,7 +63,9 @@ class OIDCAuthentication(OIDCAuthenticationInterface):
             raise OIDCException("Endpoints not provided")
 
     def set_from_well_known(self):
-        endpoints = self.to_dict_or_raise(requests.get(self.config.well_known_endpoint))
+        endpoints = self.to_dict_or_raise(
+            requests.get(self.config.well_known_endpoint)
+        )
         self.issuer = endpoints.get("issuer")
         self.authorization_endpoint = endpoints.get("authorization_endpoint")
         self.token_endpoint = endpoints.get("token_endpoint")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "0.1.1"
+version = "1.0.0"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,8 +46,7 @@ def oidc_well_known_response():
 
 def oidc_config():
     return OIDCConfig(
-        host="http://keycloak.busykoala.ch",
-        realm="example-realm",
+        well_known_endpoint="http://keycloak.busykoala.ch/auth/realms/example-realm/.well-known/openid-configuration",  # noqa
         app_uri="http://fastapi-app.busykoala.ch",
         client_id="example-client",
         client_secret="secret",


### PR DESCRIPTION
## Purpose

The well-known endpoint was Keycloak specific and also didn´t allow to use of the OIDC authentication without the
use of a well-known endpoint. With the change of this PR the interface of the OIDC config object changes so that
one can choose between providing the _complete_ well-known endpoint or all the endpoints (allowing to operate with
brokers not having a well-known endpoint).

Close #12 

## Approach

The PR adapts the OIDC config object allowing the different approach plus checks which approach was chosen within the init
method (raising an exception if the information provided will not be sufficient).

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes