### PR TITLE
Make jwks endpoint optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.0.1] - 2021-04-25
 
 - Remove uvicorn as a pkg dependency.
+- Make OIDC jkws endpoint optional (not necessary for the HS256 algorithm).
 
 ## [1.0.0] - 2021-04-22
 

--- a/fastapi_opa/auth/auth_oidc.py
+++ b/fastapi_opa/auth/auth_oidc.py
@@ -50,7 +50,6 @@ class OIDCAuthentication(OIDCAuthenticationInterface):
             self.config.issuer
             and self.config.authorization_endpoint
             and self.config.token_endpoint
-            and self.config.jwks_uri
         ):
             self.issuer = self.config.issuer
             self.authorization_endpoint = self.config.authorization_endpoint
@@ -147,6 +146,11 @@ class OIDCAuthentication(OIDCAuthenticationInterface):
                     "An error occurred while decoding the id_token"
                 )
         elif alg == "RS256":
+            if not self.jwks_uri:
+                logger.error("JWKS endpoint not provided but RS256 used.")
+                raise OIDCException(
+                    "JWKS endpoint not provided but RS256 used."
+                )
             response = requests.get(self.jwks_uri)
             web_key_sets = self.to_dict_or_raise(response)
             keys = web_key_sets.get("keys")


### PR DESCRIPTION
## Purpose

The endpoint is not necessary if the HS256 algorithm is used and therefore should be optional for the oidc flow.
The provided fix will raise an exception in the context of not having an endpoint.

Close #16

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes