### PR TITLE
Skip options request and switch redirect code

### DIFF
--- a/fastapi_opa/auth/auth_oidc.py
+++ b/fastapi_opa/auth/auth_oidc.py
@@ -90,7 +90,7 @@ class OIDCAuthentication(AuthInterface):
 
         # redirect to id provider if code query-value is not present
         if not code:
-            return RedirectResponse(self.get_auth_redirect_uri(callback_uri))
+            return RedirectResponse(url=self.get_auth_redirect_uri(callback_uri), status_code=303)
 
         auth_token = self.get_auth_token(code, callback_uri)
         id_token = auth_token.get("id_token")

--- a/fastapi_opa/auth/auth_oidc.py
+++ b/fastapi_opa/auth/auth_oidc.py
@@ -90,7 +90,9 @@ class OIDCAuthentication(AuthInterface):
 
         # redirect to id provider if code query-value is not present
         if not code:
-            return RedirectResponse(url=self.get_auth_redirect_uri(callback_uri), status_code=303)
+            return RedirectResponse(
+                url=self.get_auth_redirect_uri(callback_uri), status_code=303
+            )
 
         auth_token = self.get_auth_token(code, callback_uri)
         id_token = auth_token.get("id_token")

--- a/fastapi_opa/opa/opa_middleware.py
+++ b/fastapi_opa/opa/opa_middleware.py
@@ -27,6 +27,9 @@ class OPAMiddleware:
         self, scope: Scope, receive: Receive, send: Send
     ) -> None:
         request = Request(scope, receive, send)
+        if request.method == "OPTIONS":
+            return await self.app(scope, receive, send)
+
         # authenticate user or get redirect to identity provider
         try:
             user_info_or_auth_redirect = (


### PR DESCRIPTION
## Purpose

1. CORS "OPTIONS" requests should be not handled. 
2. When redirecting authorization request to identity provider, we should use 303 and not default 307, so that the method is switched to GET.

## Approach

_How does this change address the problem?_

## Checklist for PRs

- [ ] There is a Changelog (`/CHANGELOG.md`)
- [ ] Version was adapted if necessary (`/pyproject.toml`)
- [ ] I tested the feature if necessary (unittests, manual testing)
- [ ] If libraries aren't used for all package usages they are extras
- [ ] I documented the changes

## Learning

_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
