### PR TITLE
Allow openapi endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow updating fastapi >= 0.66 and force updating because of CVE in
   versions < 0.65.2.
+- Stop protecting the openapi endpoints by this middleware.
 
 ## [1.3.0] - 2021-08-08
 

--- a/fastapi_opa/opa/opa_middleware.py
+++ b/fastapi_opa/opa/opa_middleware.py
@@ -27,6 +27,12 @@ class OPAMiddleware:
         self, scope: Scope, receive: Receive, send: Send
     ) -> None:
         request = Request(scope, receive, send)
+        # allow openapi endpoints without authentication
+        if any(
+            request.url.path == endpoint
+            for endpoint in ["/openapi.json", "/docs", "/redoc"]
+        ):
+            return await self.app(scope, receive, send)
         # authenticate user or get redirect to identity provider
         try:
             user_info_or_auth_redirect = (

--- a/tests/test_opa.py
+++ b/tests/test_opa.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from lxml import html
 from mock import patch
 
 from fastapi_opa import OPAConfig
@@ -78,3 +79,23 @@ async def test_function_injection(injected_client):
 
     payload = json.loads(req.call_args_list[0][1].get("data")).get("input")
     assert expected_payload == payload
+
+
+def test_openapi_docs_endpoint_accessable(client):
+    response = client.get("/docs")
+    doc = html.fromstring(response.content)
+    title = doc.xpath(".//title")[0].text
+    assert "FastAPI - Swagger UI" == title
+
+
+def test_openapi_redoc_endpoint_accessable(client):
+    response = client.get("/redoc")
+    doc = html.fromstring(response.content)
+    title = doc.xpath(".//title")[0].text
+    assert "FastAPI - ReDoc" == title
+
+
+def test_openapi_json_endpoint_accessable(client):
+    response = client.get("/openapi.json")
+    title = response.json()["info"]["title"]
+    assert "FastAPI" == title


### PR DESCRIPTION
## Purpose

Close #35 

Fastapi brings openapi docs by default.
The endpoints (/docs, /redoc and openapi.json) should not be protected by this middleware.
If they need to be hidden this can be done by changing the apps settings instead:
https://fastapi.tiangolo.com/advanced/conditional-openapi/?h=openapi#conditional-openapi-from-settings-and-env-vars

:exclamation: The fix does not yet modify the docs so that the endpoints appear protected.

## Approach

The change excludes the endpoint `/docs`, `/redoc` and `/openapi.json` from being protected by the middleware.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes