### PR TITLE
Implement skip_endpoints + format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [1.3.2] - 2022-03-10
-- Add the option to skip an injectable for some given endpoints.
+- Add the option to skip some given endpoints (middleware + injectable).
 
 ## [1.3.1] - 2021-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [1.3.2] - 2022-03-10
 - Add the option to skip some given endpoints (middleware + injectable).
+- Allow authentication through bearer token
+- Fix a bug with graphql injectable
 
 ## [1.3.1] - 2021-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.3.2] - 2022-03-10
+- Add the option to skip an injectable for some given endpoints.
+
 ## [1.3.1] - 2021-09-19
 
 - Allow updating fastapi >= 0.66 and force updating because of CVE in

--- a/README.md
+++ b/README.md
@@ -209,6 +209,6 @@ For GraphQL there is a ready to use injectable:
 ```python
 from fastapi_opa.opa.enrichment.graphql_enrichment import GraphQLInjectable`
 
-graphql = FancyInjectable("gql_injectable")
+graphql = GraphQLInjectable("gql_injectable")
 opa_config = OPAConfig(authentication=oidc_auth, opa_host=opa_host, injectables=[graphql])
 ```

--- a/README.md
+++ b/README.md
@@ -189,17 +189,26 @@ class FancyInjectable(Injectable):
     async def extract(self, request: Request) -> List:
         return ["some", "custom", "stuff"]
 
-fancy_inj = FancyInjectable("fancy_key")
+fancy_inj = FancyInjectable("fancy_key", skip_endpoints=["/health"])
 
 opa_config = OPAConfig(
     authentication=oidc_auth, opa_host=opa_host, injectables=[fancy_inj]
 )
 ```
 
+With `skip_endpoints`, you can define some endpoints where the injectable
+will not be applied.
+
 
 <a name="gql-enrichment"/>
 
 ### Graphql Enrichment
 
-For GraphQL there is a ready to use injectable in
-`fastapi_opa.opa.enrichment.graphql_enrichment.GraphQLInjectable`
+For GraphQL there is a ready to use injectable:
+
+```python
+from fastapi_opa.opa.enrichment.graphql_enrichment import GraphQLInjectable`
+
+graphql = FancyInjectable("gql_injectable")
+opa_config = OPAConfig(authentication=oidc_auth, opa_host=opa_host, injectables=[graphql])
+```

--- a/fastapi_opa/auth/auth_oidc.py
+++ b/fastapi_opa/auth/auth_oidc.py
@@ -87,15 +87,19 @@ class OIDCAuthentication(AuthInterface):
             ]
         )
         code = request.query_params.get("code")
+        bearer = request.headers.get("Authorization")
 
         # redirect to id provider if code query-value is not present
-        if not code:
+        if not code and not bearer:
             return RedirectResponse(
                 url=self.get_auth_redirect_uri(callback_uri), status_code=303
             )
 
-        auth_token = self.get_auth_token(code, callback_uri)
-        id_token = auth_token.get("id_token")
+        if not bearer:
+            auth_token = self.get_auth_token(code, callback_uri)
+            id_token = auth_token.get("id_token")
+        else:
+            id_token = bearer.replace("Bearer ", "")
         try:
             alg = jwt.get_unverified_header(id_token).get("alg")
         except DecodeError:

--- a/fastapi_opa/example_oidc.py
+++ b/fastapi_opa/example_oidc.py
@@ -30,6 +30,4 @@ app.add_middleware(OPAMiddleware, config=opa_config)
 
 @app.get("/")
 async def root() -> Dict:
-    return {
-        "msg": "success",
-    }
+    return {"msg": "success"}

--- a/fastapi_opa/example_saml.py
+++ b/fastapi_opa/example_saml.py
@@ -25,6 +25,4 @@ app.add_middleware(
 
 @app.get("/")
 async def root(request: Request) -> Dict:
-    return {
-        "msg": request.session.get("foo"),
-    }
+    return {"msg": request.session.get("foo")}

--- a/fastapi_opa/opa/opa_config.py
+++ b/fastapi_opa/opa/opa_config.py
@@ -9,8 +9,9 @@ from fastapi_opa.auth.auth_interface import AuthInterface
 
 
 class Injectable(ABC):
-    def __init__(self, key: str) -> None:
+    def __init__(self, key: str, skip_endpoints: list = []) -> None:
         self.key = key
+        self.skip_endpoints = skip_endpoints
 
     @abstractmethod
     async def extract(self, request: Request) -> List:

--- a/fastapi_opa/opa/opa_middleware.py
+++ b/fastapi_opa/opa/opa_middleware.py
@@ -40,8 +40,8 @@ class OPAMiddleware:
 
         # authenticate user or get redirect to identity provider
         try:
-            user_info_or_auth_redirect = (
-                self.config.authentication.authenticate(request)
+            user_info_or_auth_redirect = self.config.authentication.authenticate(
+                request
             )
             if asyncio.iscoroutine(user_info_or_auth_redirect):
                 user_info_or_auth_redirect = await user_info_or_auth_redirect
@@ -59,6 +59,9 @@ class OPAMiddleware:
         # Enrich user_info if injectables are provided
         if self.config.injectables:
             for injectable in self.config.injectables:
+                # Skip endpoints if needed
+                if request.url.path in injectable.skip_endpoints:
+                    continue
                 user_info_or_auth_redirect[
                     injectable.key
                 ] = await injectable.extract(request)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.3.1"
+version = "1.3.2"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,7 @@ def client():
 
     @app.get("/")
     async def root() -> Dict:
-        return {
-            "msg": "success",
-        }
+        return {"msg": "success"}
 
     yield TestClient(app)
 
@@ -46,9 +44,7 @@ def injected_client():
 
     @app.get("/")
     async def root() -> Dict:
-        return {
-            "msg": "success",
-        }
+        return {"msg": "success"}
 
     yield TestClient(app)
 
@@ -68,8 +64,6 @@ async def gql_injected_client():
     @app.get("/")
     @pytest.mark.asyncio
     async def root() -> Dict:
-        return {
-            "msg": "success",
-        }
+        return {"msg": "success"}
 
     yield TestClient(app)


### PR DESCRIPTION
## Purpose

In my software, I have a mix of graphql and rest endpoints, so I need to use an injectable only on the graphql endpoints. We also wish to use some bearer token. Finally, the graphql injectable is not working in the current state (see https://github.com/tiangolo/fastapi/issues/394) for more details on the issue. I am proposing a simple hack.

## Approach

We can now specify some endpoints to skip for an injectable and can use bearer token.

## Checklist for PRs

- [x ] There is a Changelog (`/CHANGELOG.md`)
- [x ] Version was adapted if necessary (`/pyproject.toml`)
- [x ] I tested the feature if necessary (unittests, manual testing)
- [x ] If libraries aren't used for all package usages they are extras
- [x ] I documented the changes

