### PR TITLE
Implement properly access tokens, improve skip endpoints with regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.3.3] - 2022-04-06
+- Uses regex to skip endpoints
+- Properly implement the usage of access tokens
+- Add an option to allow id tokens or access tokens
+
 ## [1.3.2] - 2022-03-10
 - Add the option to skip some given endpoints (middleware + injectable).
 - Allow authentication through bearer token

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ opa_host = "http://localhost:8181"
 saml_config = SAMLConfig(settings_directory="./tests/test_data/saml")
 saml_auth = SAMLAuthentication(saml_config)
 
-opa_config = OPAConfig(authentication=saml_auth, opa_host=opa_host)
+opa_config = OPAConfig(authentication=saml_auth, opa_host=opa_host,
+                       accepted_methods=["id_token", "access_token"])
 ```
 
 The cert has to be uploaded to your identity provider. Using Keycloak as an
@@ -189,7 +190,7 @@ class FancyInjectable(Injectable):
     async def extract(self, request: Request) -> List:
         return ["some", "custom", "stuff"]
 
-fancy_inj = FancyInjectable("fancy_key", skip_endpoints=["/health"])
+fancy_inj = FancyInjectable("fancy_key", skip_endpoints=["/health", "/api/[^/]*/test])
 
 opa_config = OPAConfig(
     authentication=oidc_auth, opa_host=opa_host, injectables=[fancy_inj]
@@ -197,7 +198,8 @@ opa_config = OPAConfig(
 ```
 
 With `skip_endpoints`, you can define some endpoints where the injectable
-will not be applied.
+will not be applied. The endpoints can be defined either directly or through some
+regex.
 
 
 <a name="gql-enrichment"/>

--- a/fastapi_opa/opa/enrichment/graphql_enrichment.py
+++ b/fastapi_opa/opa/enrichment/graphql_enrichment.py
@@ -14,6 +14,7 @@ from graphql import GraphQLSchema
 from graphql import GraphQLString
 from graphql.language.ast import ListType
 from graphql.language.ast import NamedType
+from graphql.language.ast import NonNullType
 from graphql.language.ast import OperationDefinition
 from graphql.language.ast import SelectionSet
 from graphql.language.ast import VariableDefinition
@@ -93,6 +94,8 @@ class GraphQLAnalysis:
     ) -> str:
         if isinstance(item_type, ListType):
             return self.deep_extract_type(item_type.type, "[{}]")
+        elif isinstance(item_type, NonNullType):
+            return type_str.format(item_type.type.name.value)
         else:
             return type_str.format(item_type.name.value)
 

--- a/fastapi_opa/opa/opa_config.py
+++ b/fastapi_opa/opa/opa_config.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC
 from abc import abstractmethod
 from typing import List
@@ -9,9 +10,11 @@ from fastapi_opa.auth.auth_interface import AuthInterface
 
 
 class Injectable(ABC):
-    def __init__(self, key: str, skip_endpoints: list = []) -> None:
+    def __init__(
+        self, key: str, skip_endpoints: Optional[List[str]] = []
+    ) -> None:
         self.key = key
-        self.skip_endpoints = skip_endpoints
+        self.skip_endpoints = [re.compile(skip) for skip in skip_endpoints]
 
     @abstractmethod
     async def extract(self, request: Request) -> List:
@@ -24,7 +27,9 @@ class OPAConfig:
         authentication: AuthInterface,
         opa_host: str,
         injectables: Optional[List[Injectable]] = None,
+        accepted_methods: Optional[List[str]] = ["id_token", "access_token"],
     ) -> None:
         self.authentication = authentication
         self.opa_url = f"{opa_host.rstrip('/')}/v1/data/httpapi/authz"
         self.injectables = injectables
+        self.accepted_methods = accepted_methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.3.2"
+version = "1.3.3"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,10 +12,10 @@ from fastapi_opa.auth.auth_interface import AuthInterface
 from fastapi_opa.opa.opa_config import Injectable
 
 
-def mock_response(status_code, json_data=None):
+def mock_response(status_code, json_data=None, **kwargs):
     json_ = Mock()
     json_.return_value = json_data
-    return Mock(status_code=status_code, json=json_)
+    return Mock(status_code=status_code, json=json_, **kwargs)
 
 
 # ***************************


### PR DESCRIPTION
## Purpose

 - Properly implement the access tokens
 - Skip endpoints now uses regex
 - Add the option to disable the id tokens or the access tokens

## Approach

- For the id token, we are already using the access token. So in my implementation of the access token, I am simply skipping all the non necessary steps.
- I created a new function that check each regex in `skip_endpoints`.
- I have added a new parameter to `OpaConfig` in order to use either id tokens or the access tokens (or both). 

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes
