### PR TITLE
Add missing contrib avatars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-## [1.3.3] - 2022-04-06
+## [1.3.3] - 2022-04-09
 - Uses regex to skip endpoints
 - Properly implement the usage of access tokens
 - Add an option to allow id tokens or access tokens
+- Replace contrib.rocks img with manual list
 
 ## [1.3.2] - 2022-03-10
 - Add the option to skip some given endpoints (middleware + injectable).

--- a/README.md
+++ b/README.md
@@ -16,11 +16,20 @@
 
 ## Contributors
 
-<a href="https://github.com/busykoala/fastapi-opa/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=busykoala/fastapi-opa" />
-</a>
+Thanks to all our contributors! There is no specific order and hopefully nobody was left out.
 
-Made with [contributors-img](https://contrib.rocks).
+<a href="https://github.com/morestanna">
+  <img src="https://avatars.githubusercontent.com/morestanna" width="60" height="60" />
+</a>
+<a href="https://github.com/busykoala">
+  <img src="https://avatars.githubusercontent.com/busykoala" width="60" height="60" />
+</a>
+<a href="https://github.com/TracyWR">
+  <img src="https://avatars.githubusercontent.com/TracyWR" width="60" height="60" />
+</a>
+<a href="https://github.com/loikki">
+  <img src="https://avatars.githubusercontent.com/loikki" width="60" height="60" />
+</a>
 
 <a name="about"/>
 


### PR DESCRIPTION
## Purpose

Contributors were listed using contrib.rocks. Since the contribution graph does not seem to show fork-PR contributions this MR adds a list of manual avatars.
Also the avatars include a URL to the user profiles now.

## Approach

contrib.rocks is replaced with a manual list of avatars using the github API endpoint.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes
