### PR TITLE
Skip lifespan events (server startup / shutdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.3.5] - 2022-05-16
+- Skip lifespan requests (server startup / shutdown)
+
 ## [1.3.4] - 2022-05-11
 - Improve type extraction for graphql
 

--- a/fastapi_opa/opa/opa_middleware.py
+++ b/fastapi_opa/opa/opa_middleware.py
@@ -54,6 +54,9 @@ class OPAMiddleware:
         self, scope: Scope, receive: Receive, send: Send
     ) -> None:
 
+        if scope["type"] == "lifespan":
+            return await self.app(scope, receive, send)
+
         request = Request(scope, receive, send)
 
         if request.method == "OPTIONS":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.3.4"
+version = "1.3.5"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Purpose

When using startup events in some endpoints (`@fastapi.APIRouter().on_event("startup")`), fastapi-opa is crashing the initialization.

## Approach

The middleware is now skipping all the requests with type "lifespan" (see https://asgi.readthedocs.io/en/latest/specs/lifespan.html)

I have manually tested within phisherman and everything is working with this change.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes
