### PR TITLE
Fix multiple access to request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.3.6] - 2022-05-23
+- Fix multiple usage of the request body
+
 ## [1.3.5] - 2022-05-16
 - Skip lifespan requests (server startup / shutdown)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.3.5"
+version = "1.3.6"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Purpose

Starlette does not allow to access the body of a request multiple times. The current solution requires mock but it does not work when processing multiple requests at the same time (memory corruption and then all the requests will receive the same response).

## Approach

Here, I am manually mocking the receive variable and send it back to the middleware stack. The difference with the previous solution is that I am doing a local mock and not a global one.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes
