### PR TITLE
Implement API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.3.8] - 2022-07-05
+- Add should_skip_authorization in order to implement API keys
+
 ## [1.3.7] - 2022-05-26
 - Bump pyjwt due to vulnerability [CVE-2022-29217](https://github.com/advisories/GHSA-ffqj-6fqr-9h24)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Authentication Flow](#auth-flow)
   - [OIDC Authentication](#oidc-auth)
   - [SAML Authentication](#saml-auth)
+- [Implementing an API Key](#api-key)
 - [Custom Payload Enrichment](#custom-payload-enrichment)
   - [Graphql Enrichment](#gql-enrichment)
 
@@ -184,6 +185,29 @@ idp you need to configure `encrypt assertion`, `client signature required`,
 `force POST bindings` on creating the client.
 Also configure: `Client Scopes` -> `role_list (saml)` -> `Mappers tab` ->
 `role list` -> `Single Role Attribute`
+
+<a name="api-key"/>
+
+## Implementing an API key
+If you need to skip the authorization process for some services, you can use an API key shared
+between the two services:
+
+```python
+api_key_header = "API-KEY"
+api_key_value = "1234"
+def skip_api_key(request: Request):
+    if api_key_header not in request.headers:
+        return False
+    return request.headers[api_key_header] == api_key_value
+
+opa_config = OPAConfig(authentication=oidc_auth, opa_host=opa_host)
+app.add_middleware(
+    OPAMiddleware,
+    config=opa_config,
+    should_skip_authorization=[skip_api_key],
+)
+```
+
 
 <a name="custom-payload-enrichment"/>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.3.7"
+version = "1.3.8"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Purpose

For some services, we need an efficient way to access some endpoints protected by fastapi-opa without going through the authentication server.

## Approach

Here, I am implementing a new skip options where you can define any type of check. Thanks to that, we can create an API key shared between services which allows us to bypass the authentication.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes

## Notes

I had to split the `__call__` function due to a high complexity according to flake8.