### PR TITLE
Implement API Key + allow multiple authentication methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.4.0] - 2022-07-12
+- Add API Key authentication
+- Add options to allow multiple authentication methods
+
 ## [1.3.7] - 2022-05-26
 - Bump pyjwt due to vulnerability [CVE-2022-29217](https://github.com/advisories/GHSA-ffqj-6fqr-9h24)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [How to get started](#getting-started)
 - [Open Policy Agent](#opa)
 - [Authentication Flow](#auth-flow)
+  - [API Key Authentication](#api-key-auth)
   - [OIDC Authentication](#oidc-auth)
   - [SAML Authentication](#saml-auth)
 - [Custom Payload Enrichment](#custom-payload-enrichment)
@@ -145,6 +146,23 @@ flow and inject it into OPAMiddleware
 request if you would like to contribute to the package.
 
 Also there are implementations ready to use.
+
+<a name="api-key-auth"/>
+
+### API Key Authentication
+
+The API key authentication is the simplest authentication system where you simply needs to match
+a given value in the request header:
+```python
+# Configure API keys
+api_key_config = APIKeyConfig(
+    header_key="test",
+    api_key="1234"
+)
+api_key_auth = APIKeyAuthentication(api_key_config)
+```
+Here sending a request with the `header["test"] = "1234"` would be considered as a successful authentication.
+For OPA, the user is `APIKey` and the variable `client` is set with the client address.
 
 <a name="oidc-auth"/>
 

--- a/fastapi_opa/auth/auth_api_key.py
+++ b/fastapi_opa/auth/auth_api_key.py
@@ -1,0 +1,38 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from fastapi_opa.auth.auth_interface import AuthInterface
+from fastapi_opa.auth.exceptions import AuthenticationException
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class APIKeyConfig:
+    header_key: str
+    api_key: str
+
+
+class APIKeyAuthentication(AuthInterface):
+    def __init__(self, config: APIKeyConfig) -> None:
+        self.config = config
+
+    async def authenticate(
+        self,
+        request: Request,
+        accepted_methods: Optional[List[str]] = [],
+    ) -> Union[Response, Dict]:
+        key = request.headers.get(self.config.header_key, None)
+        if key is None or key != self.config.api_key:
+            raise AuthenticationException("Unauthorized")
+        return {
+            "user": "APIKey",
+            "client": request.client.host,
+        }

--- a/fastapi_opa/opa/opa_config.py
+++ b/fastapi_opa/opa/opa_config.py
@@ -24,11 +24,13 @@ class Injectable(ABC):
 class OPAConfig:
     def __init__(
         self,
-        authentication: AuthInterface,
+        authentication: [AuthInterface, List[AuthInterface]],
         opa_host: str,
         injectables: Optional[List[Injectable]] = None,
         accepted_methods: Optional[List[str]] = ["id_token", "access_token"],
     ) -> None:
+        if not isinstance(authentication, list):
+            authentication = [authentication]
         self.authentication = authentication
         self.opa_url = f"{opa_host.rstrip('/')}/v1/data/httpapi/authz"
         self.injectables = injectables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.3.7"
+version = "1.4.0"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <m@osswald.li>"]
 license = "GPL-3.0-or-later"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 
 from fastapi_opa import OPAConfig
 from fastapi_opa import OPAMiddleware
+from fastapi_opa.auth.auth_api_key import APIKeyAuthentication
+from fastapi_opa.auth.auth_api_key import APIKeyConfig
 from fastapi_opa.opa.enrichment.graphql_enrichment import GraphQLInjectable
 from tests.utils import AuthenticationDummy
 from tests.utils import OPAInjectableExample
@@ -37,6 +39,34 @@ def injected_client():
     injectable = OPAInjectableExample("example_injectable")
     opa_config = OPAConfig(
         authentication=oidc_auth, opa_host=opa_host, injectables=[injectable]
+    )
+
+    app = FastAPI()
+    app.add_middleware(OPAMiddleware, config=opa_config)
+
+    @app.get("/")
+    async def root() -> Dict:
+        return {"msg": "success"}
+
+    yield TestClient(app)
+
+
+@pytest.fixture
+def api_key_auth():
+    header_key = "API"
+    api_key = "1234"
+    config = APIKeyConfig(header_key=header_key, api_key=api_key)
+    auth = APIKeyAuthentication(config)
+    yield {"auth": auth, "header_key": header_key, "api_key": api_key}
+
+
+@pytest.fixture
+def client_multiple_authentications(api_key_auth):
+    opa_host = "http://localhost:8181"
+    oidc_auth = AuthenticationDummy(accept_all=False)
+
+    opa_config = OPAConfig(
+        authentication=[oidc_auth, api_key_auth["auth"]], opa_host=opa_host
     )
 
     app = FastAPI()

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -1,0 +1,34 @@
+from collections import namedtuple
+
+import pytest
+
+from fastapi_opa.auth.exceptions import AuthenticationException
+
+FakeClient = namedtuple("FakeClient", "host")
+FakeRequest = namedtuple("FakeRequest", "headers client")
+
+
+@pytest.mark.asyncio
+async def test_key_api_auth(api_key_auth):
+    header_key = api_key_auth["header_key"]
+    api_key = api_key_auth["api_key"]
+    auth = api_key_auth["auth"]
+
+    host = "1.2.3.4"
+    fake_client = FakeClient(host)
+    fake_request = FakeRequest({header_key: api_key}, fake_client)
+
+    # Do a successful test
+    answer = await auth.authenticate(fake_request)
+    assert answer["user"] == "APIKey"
+    assert answer["client"] == host
+
+    # Do a failure due to wrong key
+    with pytest.raises(AuthenticationException):
+        fake_request = FakeRequest({header_key: "098125u"}, fake_client)
+        answer = await auth.authenticate(fake_request)
+
+    # Do a failure due to missing key
+    with pytest.raises(AuthenticationException):
+        fake_request = FakeRequest({}, fake_client)
+        answer = await auth.authenticate(fake_request)

--- a/tests/test_opa.py
+++ b/tests/test_opa.py
@@ -115,3 +115,24 @@ def test_skip_endpoints():
 
     # Test a  non match
     assert not should_skip_endpoint("/test1", skip_endpoints)
+
+
+def test_multiple_authentication(
+    api_key_auth, client_multiple_authentications
+):
+    client = client_multiple_authentications
+
+    header_key = api_key_auth["header_key"]
+    api_key = api_key_auth["api_key"]
+
+    with patch("fastapi_opa.opa.opa_middleware.requests.post") as req:
+        req.return_value.status_code = 200
+        req.return_value.json = lambda: {"result": {"allow": True}}
+        response = client.get("/")
+        assert response.status_code == 401
+
+        response = client.get("/", headers={"Authorization": "1234"})
+        assert response.status_code == 200
+
+        response = client.get("/", headers={header_key: api_key})
+        assert response.status_code == 200

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ from starlette.responses import RedirectResponse
 
 from fastapi_opa.auth import OIDCConfig
 from fastapi_opa.auth.auth_interface import AuthInterface
+from fastapi_opa.auth.exceptions import AuthenticationException
 from fastapi_opa.opa.opa_config import Injectable
 
 
@@ -22,14 +23,20 @@ def mock_response(status_code, json_data=None, **kwargs):
 # OPA Utils
 # ***************************
 class AuthenticationDummy(AuthInterface):
+    def __init__(self, accept_all=True):
+        self.accept_all = accept_all
+
     def authenticate(
-        self, *args: object, **kwargs: object
+        self, request: Request, accepted_methods=[]
     ) -> Union[RedirectResponse, Dict]:
-        return {
-            "stuff": "some info",
-            "username": "John Doe",
-            "role": "Administrator",
-        }
+        if not self.accept_all and "Authorization" not in request.headers:
+            raise AuthenticationException("Unauthorized")
+        else:
+            return {
+                "stuff": "some info",
+                "username": "John Doe",
+                "role": "Administrator",
+            }
 
 
 class OPAInjectableExample(Injectable):


### PR DESCRIPTION
## Purpose

For some services, we need an efficient way to access some endpoints protected by fastapi-opa without going through the authentication server.

## Approach

Here, I am implementing a authentication method for API key and allows multiple authentication methods in the middleware.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes
