### PR TITLE
Use x-forwarded cookies to get original path for OIDC authentication …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.4.8] - 2024-01-12
+- Optionally use `x-forwarded-` cookies when reconstructing redirect path for OIDC
+
 ## [1.4.7] - 2023-10-12
 - Add option to define package name parameter in OPA Config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.4.7"
+version = "1.4.8"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <info@busykoala.io>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Purpose

Naive fix for #68
Close #68 

## Approach

Uses `x-forwarded-` cookies to reconstruct original request path when those cookies are present.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] If libraries aren't used for all package usages they are extras
- [x] I documented the changes

## Learning

Cookies are "de-facto standard header" for [protocol](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), [host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) information when mutated by LoadBalancers etc.
SSL termination decrypts HTTPS traffic and passes plain HTTP to backend services: for some reason, this is reflected in the scoped request to the middleware.